### PR TITLE
Communicate errors back from the library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,9 @@ libzseek_la_LIBADD = $(ZSTD_LIBS) $(PTHREAD_LIBS)
 libzseek_la_SOURCES = src/seek_table.h \
 		      src/compress.c \
 		      src/decompress.c \
-		      src/seek_table.c
+		      src/seek_table.c \
+		      src/common.h \
+		      src/common.c
 
 include_HEADERS = src/zseek.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libzseek], [0.1], [Fotis Xenakis <foxen@windowslive.com>])
+AC_INIT([libzseek], [0.2.0], [Fotis Xenakis <foxen@windowslive.com>])
 
 # Before building a new release, the library version info should be modified.
 # Apply these instructions sequentially:
@@ -7,7 +7,7 @@ AC_INIT([libzseek], [0.1], [Fotis Xenakis <foxen@windowslive.com>])
 #   3. If interfaces have been added, increment age.
 #   4. If interfaces have been removed/changed, set age to 0.
 AC_SUBST(LIBZSEEK_CURRENT, 0)
-AC_SUBST(LIBZSEEK_REVISION, 0)
+AC_SUBST(LIBZSEEK_REVISION, 2)
 AC_SUBST(LIBZSEEK_AGE, 0)
 
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,55 @@
+#include <string.h>     // strerror_r
+#include <stdio.h>      // snprintf
+#include <stdarg.h>
+
+#include "zseek.h"      // ZSEEK_ERRBUF_SIZE
+
+#include "common.h"
+
+// Portable strerror_r
+static const char *xstrerror_r(int errnum, char *buf, size_t buflen)
+{
+    const char *errstr;
+
+#if (_POSIX_C_SOURCE >= 200112L) && !(defined(_GNU_SOURCE) && _GNU_SOURCE)
+    // XSI-compliant
+    if (strerror_r(errnum, buf, 1024) == 0)
+        errstr = buf;
+    else
+        errstr = "";
+    // Assume buf is always NULL-terminated (not mentioned in the docs)
+#else
+    // GNU-specific
+    errstr = strerror_r(errnum, buf, 1024);
+#endif
+
+    return errstr;
+}
+
+void set_error_with_errno(char errbuf[ZSEEK_ERRBUF_SIZE], const char *msg, int errnum)
+{
+    // "The GNU C Library uses a buffer of 1024 characters for strerror(). This
+    // buffer size therefore should be sufficient to avoid an ERANGE error when
+    // calling strerror_r()."
+    char buf2[1024];
+    const char *errstr;
+
+    errstr = xstrerror_r(errnum, buf2, 1024);
+
+    if (!msg || *msg == '\0')
+        set_error(errbuf, "%s", errstr);
+    else
+        set_error(errbuf, "%s: %s", msg, errstr);
+}
+
+
+void set_error(char errbuf[ZSEEK_ERRBUF_SIZE], const char *message, ...)
+{
+	va_list arg_ptr;
+
+	if (errbuf) {
+		va_start(arg_ptr, message);
+		vsnprintf(errbuf, ZSEEK_ERRBUF_SIZE, message, arg_ptr);
+		va_end(arg_ptr);
+	}
+}

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,20 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <stddef.h>     // size_t
+
+/**
+ * Return in @errbuf the equivalent of using perror with @msg and errno set to
+ * @errnum.
+ * If @errbuf is NULL it simply returns.
+ */
+void set_error_with_errno(char errbuf[ZSEEK_ERRBUF_SIZE], const char *msg, int errnum);
+
+/**
+ * Format a an error message into @errbuf.
+ * If @errbuf is NULL it simply returns.
+ */
+void set_error(char errbuf[ZSEEK_ERRBUF_SIZE], const char *message, ...) __attribute__ ((format(printf, 2, 3)));
+
+
+#endif  // COMMON_H

--- a/src/zseek.h
+++ b/src/zseek.h
@@ -32,8 +32,6 @@
  *  bool buffered_write(const void *data, size_t size, *user_data)
  *  bool buffered_read(void *data, size_t size, *user_data)
  *
- * @todo Consider a better name, tried to avoid the algo in the name
- *
  * @{
  */
 

--- a/test/benchmark.c
+++ b/test/benchmark.c
@@ -184,7 +184,7 @@ static results_t *compress(const char *ufilename, const char *cfilename,
 
     writer = zseek_writer_open(cfilename, nb_workers, min_frame_size, errbuf);
     if (!writer) {
-        fprintf(stderr, "compress: zseek_writer_open failed\n");
+        fprintf(stderr, "compress: zseek_writer_open: %s\n", errbuf);
         return NULL;
     }
 
@@ -201,7 +201,7 @@ static results_t *compress(const char *ufilename, const char *cfilename,
         }
 
         if (!zseek_write(writer, (uint8_t*)buf + fpos, len, errbuf)) {
-            fprintf(stderr, "compress: zseek_write failed\n");
+            fprintf(stderr, "compress: zseek_write: %s\n", errbuf);
             return NULL;
         }
 
@@ -215,7 +215,7 @@ static results_t *compress(const char *ufilename, const char *cfilename,
     }
 
     if (!zseek_writer_close(writer, errbuf)) {
-        fprintf(stderr, "compress: zseek_writer_close failed\n");
+        fprintf(stderr, "compress: zseek_writer_close: %s\n", errbuf);
         return NULL;
     }
 

--- a/test/example.c
+++ b/test/example.c
@@ -36,7 +36,7 @@ static bool decompress(const char *ufilename, const char *cfilename)
 
     reader = zseek_reader_open(cfilename, errbuf);
     if (!reader) {
-        fprintf(stderr, "decompress: zseek_reader_open failed\n");
+        fprintf(stderr, "decompress: zseek_reader_open: %s\n", errbuf);
         return false;
     }
 
@@ -71,7 +71,7 @@ static bool decompress(const char *ufilename, const char *cfilename)
             dread = zseek_pread(reader, (uint8_t*)dbuf + (offset % buf_len),
                 to_read, offset, errbuf);
             if (dread == -1) {
-                fprintf(stderr, "decompress: zseek_pread failed\n");
+                fprintf(stderr, "decompress: zseek_pread: %s\n", errbuf);
                 return false;
             }
             to_read -= dread;
@@ -96,7 +96,7 @@ static bool decompress(const char *ufilename, const char *cfilename)
     free(ubuf);
 
     if (!zseek_reader_close(reader, errbuf)) {
-        fprintf(stderr, "decompress: zseek_reader_close failed\n");
+        fprintf(stderr, "decompress: zseek_reader_close: %s\n", errbuf);
         return false;
     }
 
@@ -129,7 +129,7 @@ static bool compress(const char *ufilename, const char *cfilename)
 
     writer = zseek_writer_open(cfilename, NB_WORKERS, MIN_FRAME_SIZE, errbuf);
     if (!writer) {
-        fprintf(stderr, "compress: zseek_writer_open failed\n");
+        fprintf(stderr, "compress: zseek_writer_open: %s\n", errbuf);
         return false;
     }
 
@@ -149,7 +149,7 @@ static bool compress(const char *ufilename, const char *cfilename)
         }
 
         if (!zseek_write(writer, buf, uread, errbuf)) {
-            fprintf(stderr, "compress: zseek_write failed\n");
+            fprintf(stderr, "compress: zseek_write: %s\n", errbuf);
             return false;
         }
     } while (!feof(fin));
@@ -158,7 +158,7 @@ static bool compress(const char *ufilename, const char *cfilename)
     free(buf);
 
     if (!zseek_writer_close(writer, errbuf)) {
-        fprintf(stderr, "compress: zseek_writer_close failed\n");
+        fprintf(stderr, "compress: zseek_writer_close: %s\n", errbuf);
         return false;
     }
 


### PR DESCRIPTION
This adds proper error reporting using the errbuf argument as specified in the API.