### PR TITLE
Prevent concurrent file modifications

### DIFF
--- a/src/compress.c
+++ b/src/compress.c
@@ -86,7 +86,7 @@ zseek_writer_t *zseek_writer_open(const char *filename, int nb_workers,
     }
     writer->fl = fl;
 
-    fout = fopen(filename, "wb");
+    fout = fopen(filename, "wbx");
     if (!fout) {
         set_error_with_errno(errbuf, "open file", errno);
         goto fail_w_framelog;

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -124,7 +124,7 @@ ssize_t zseek_pread(zseek_reader_t *reader, void *buf, size_t count,
 {
     ssize_t frame_idx = 0;
     int pr = 0;
-    void *cbuf = NULL; // Declared here to be in scope at fail_w_cbuf
+    void *cbuf = NULL;
     size_t offset_in_frame = 0;
     size_t to_copy = 0;
 


### PR DESCRIPTION
This ensures we always error out when there's concurrent writers or readers/writers, without corrupting the archive.