### PR TITLE
Clarify start_offset support

### DIFF
--- a/src/zseek.h
+++ b/src/zseek.h
@@ -15,16 +15,6 @@
  * The block sizes are tuned to achieve high throughput write without
  * prohibitive read amplification.
  *
- * Additional considerations:
- *
- * An initial segment of the file is uncompressed,
- * and can be used to store metadata by overwriting in-place by the caller
- * after the compression is concluded.
- * This is represented by the start_offset parameter.
- * Separately, we are looking into changing the potential users to append
- * their metadata to the end of the file,
- * so that we can eliminate this feature.
- *
  * @{
  */
 


### PR DESCRIPTION
This introduces the `start_offset` parameter to the API, allowing the user to leave an initial segment of the file uncompressed, possibly to be used for custom file metadata. Note that it's **up to the user** to track this value for each file.

This required changing the pluggable I/O API for writing, since we now need to seek into the output file. Mainly for symmetry with the read API, I went for a `pwrite()`-like interface. The alternative would be to stick to the `write()` function previously required, adding a seek function (which would be more efficient in the default case). What are your thoughts on this?

Fixes https://github.com/foxeng/libzseek/issues/11.