### PR TITLE
tests: Downgrade libcheck

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([libzseek], [0.2.0], [Fotis Xenakis <foxen@windowslive.com>])
 #   3. If interfaces have been added, increment age.
 #   4. If interfaces have been removed/changed, set age to 0.
 AC_SUBST(LIBZSEEK_CURRENT, 0)
-AC_SUBST(LIBZSEEK_REVISION, 0)
+AC_SUBST(LIBZSEEK_REVISION, 1)
 AC_SUBST(LIBZSEEK_AGE, 0)
 
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ LT_INIT
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 
 PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.4.9])
-PKG_CHECK_MODULES([CHECK], [check >= 0.15.2])
+PKG_CHECK_MODULES([CHECK], [check])
 
 AX_IS_RELEASE([git-directory])
 AX_COMPILER_FLAGS([WARN_CFLAGS],[WARN_LDFLAGS],,,[ dnl

--- a/test/test_cache.c
+++ b/test/test_cache.c
@@ -9,14 +9,14 @@
 START_TEST(test_cache_new_null)
 {
     zseek_cache_t *cache = zseek_cache_new(0);
-    ck_assert_ptr_null(cache);
+    ck_assert(cache == NULL);
 }
 END_TEST
 
 START_TEST(test_cache_new)
 {
     zseek_cache_t *cache = zseek_cache_new(3);
-    ck_assert_ptr_nonnull(cache);
+    ck_assert(cache != NULL);
 
     zseek_cache_free(cache);
 }
@@ -76,7 +76,7 @@ END_TEST
 START_TEST(test_cache_find_null)
 {
     zseek_frame_t frame = zseek_cache_find(NULL, 0);
-    ck_assert_ptr_null(frame.data);
+    ck_assert(frame.data == NULL);
 }
 END_TEST
 
@@ -86,7 +86,7 @@ START_TEST(test_cache_find_empty)
     ck_assert_msg(cache != NULL, "failed to create cache");
 
     zseek_frame_t found = zseek_cache_find(cache, 1);
-    ck_assert_ptr_null(found.data);
+    ck_assert(found.data == NULL);
 
     zseek_cache_free(cache);
 }
@@ -102,9 +102,9 @@ START_TEST(test_cache_find_present)
     ck_assert_msg(zseek_cache_insert(cache, frame), "failed to insert frame");
 
     zseek_frame_t found = zseek_cache_find(cache, 1);
-    ck_assert_ptr_eq(found.data, frame.data);
-    ck_assert_uint_eq(found.idx, frame.idx);
-    ck_assert_uint_eq(found.len, frame.len);
+    ck_assert(found.data == frame.data);
+    ck_assert(found.idx == frame.idx);
+    ck_assert(found.len == frame.len);
 
     zseek_cache_free(cache);
 }
@@ -126,7 +126,7 @@ START_TEST(test_cache_find_absent)
         "failed to insert frame %zu", frame.idx);
 
     zseek_frame_t found = zseek_cache_find(cache, 3);
-    ck_assert_ptr_null(found.data);
+    ck_assert(found.data == NULL);
 
     zseek_cache_free(cache);
 }
@@ -146,16 +146,17 @@ START_TEST(test_cache_replace)
     }
 
     zseek_frame_t found = zseek_cache_find(cache, 0);
-    ck_assert_ptr_null(found.data);
+    ck_assert(found.data == NULL);
     for (int i = 1; i < 4; i++) {
         found = zseek_cache_find(cache, i);
-        ck_assert_ptr_eq(found.data, frames[i].data);
-        ck_assert_uint_eq(found.idx, frames[i].idx);
-        ck_assert_uint_eq(found.len, frames[i].len);
+        ck_assert(found.data == frames[i].data);
+        ck_assert(found.idx == frames[i].idx);
+        ck_assert(found.len == frames[i].len);
     }
 
     zseek_cache_free(cache);
 }
+END_TEST
 
 Suite *cache_suite(void)
 {
@@ -190,3 +191,4 @@ int main(void)
 
     return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
+


### PR DESCRIPTION
Fixed a problem in test and removed version enforcement from check, made it compatible with older version as OBS (build.opensuse.org) doesn't has the newer one.