### PR TITLE
Add lz4 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,9 +15,9 @@ lib_LTLIBRARIES = libzseek.la
 
 libzseek_la_LDFLAGS = $(WARN_LDFLAGS) -version-info $(LIBZSEEK_CURRENT):$(LIBZSEEK_REVISION):$(LIBZSEEK_AGE)
 
-libzseek_la_CFLAGS = $(AM_CFLAGS) $(ZSTD_CFLAGS)
+libzseek_la_CFLAGS = $(AM_CFLAGS) $(ZSTD_CFLAGS) $(LZ4_CFLAGS)
 libzseek_la_CPPFLAGS = $(AM_CPPFLAGS)
-libzseek_la_LIBADD = $(ZSTD_LIBS) $(PTHREAD_LIBS)
+libzseek_la_LIBADD = $(ZSTD_LIBS) $(LZ4_LIBS) $(PTHREAD_LIBS)
 
 libzseek_la_SOURCES = src/seek_table.h \
 		      src/compress.c \
@@ -35,10 +35,10 @@ include_HEADERS = src/zseek.h
 noinst_PROGRAMS = benchmark example test_cache test_buffer
 
 benchmark_SOURCES = test/benchmark.c $(HEADERS)
-benchmark_LDADD = $(ZSTD_LIBS) -lm $(top_builddir)/libzseek.la
+benchmark_LDADD = $(ZSTD_LIBS) $(LZ4_LIBS) -lm $(top_builddir)/libzseek.la
 
 example_SOURCES = test/example.c $(HEADERS)
-example_LDADD = $(ZSTD_LIBS) -lm $(top_builddir)/libzseek.la
+example_LDADD = $(ZSTD_LIBS) $(LZ4_LIBS) -lm $(top_builddir)/libzseek.la
 
 test_cache_SOURCES = test/test_cache.c $(top_builddir)/src/cache.h
 test_cache_CFLAGS = @CHECK_CFLAGS@

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,11 +26,13 @@ libzseek_la_SOURCES = src/seek_table.h \
 		      src/common.h \
 		      src/common.c \
 			  src/cache.h \
-			  src/cache.c
+			  src/cache.c \
+			  src/buffer.h \
+			  src/buffer.c
 
 include_HEADERS = src/zseek.h
 
-noinst_PROGRAMS = benchmark example test_cache
+noinst_PROGRAMS = benchmark example test_cache test_buffer
 
 benchmark_SOURCES = test/benchmark.c $(HEADERS)
 benchmark_LDADD = $(ZSTD_LIBS) -lm $(top_builddir)/libzseek.la
@@ -41,3 +43,7 @@ example_LDADD = $(ZSTD_LIBS) -lm $(top_builddir)/libzseek.la
 test_cache_SOURCES = test/test_cache.c $(top_builddir)/src/cache.h
 test_cache_CFLAGS = @CHECK_CFLAGS@
 test_cache_LDADD = -lm $(top_builddir)/libzseek.la @CHECK_LIBS@
+
+test_buffer_SOURCES = test/test_buffer.c $(top_builddir)/src/buffer.h
+test_buffer_CFLAGS = @CHECK_CFLAGS@
+test_buffer_LDADD = -lm $(top_builddir)/libzseek.la @CHECK_LIBS@

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Random access decompression, using zstd.
+Random access decompression, using zstd or lz4.
 
 # General
 
@@ -20,7 +20,7 @@ Elementary test to compress, decomporess and validate a user-specified file. See
 `test/example.c`.
 
 ```sh
-./example <path-to-uncompressed-file>
+./example --zstd|--lz4 <path-to-uncompressed-file>
 ```
 
 # Benchmark
@@ -33,23 +33,21 @@ See `test/benchmark.c`.
 For a single run:
 
 ```sh
-./benchmark <path-to-uncompressed-file> <workers> <frame-size>
+./benchmark --zstd|--lz4 <path-to-uncompressed-file> <workers> <frame-size>
 ```
 
 For multiple runs:
 
 ```sh
 # See/edit benchmark.sh for the # of workers/min frame sizes to test
-./benchmark.sh <path-to-uncompressed-file> | tee report.txt
+./benchmark.sh --zstd|--lz4 <path-to-uncompressed-file> | tee report.txt
 ./report.awk
 ```
 
 # TODO
 
 - More tests: standalone, multi-threaded.
-- Pluggable I/O.
 - Pluggable memory management.
-- Parameterize/tune cache size and compression level.
 - Dictionaries?
 - OPT: Stop relying on zstd's multi-threading?
   - Pro: could use vanilla-built zstd.

--- a/configure.ac
+++ b/configure.ac
@@ -6,9 +6,9 @@ AC_INIT([libzseek], [0.2.0], [Fotis Xenakis <foxen@windowslive.com>])
 #   2. If interfaces have been added/removed/changed, increment current and set revision to 0.
 #   3. If interfaces have been added, increment age.
 #   4. If interfaces have been removed/changed, set age to 0.
-AC_SUBST(LIBZSEEK_CURRENT, 1)
+AC_SUBST(LIBZSEEK_CURRENT, 2)
 AC_SUBST(LIBZSEEK_REVISION, 0)
-AC_SUBST(LIBZSEEK_AGE, 1)
+AC_SUBST(LIBZSEEK_AGE, 0)
 
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign subdir-objects silent-rules])

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,7 @@ LT_INIT
 AX_PTHREAD([], [AC_MSG_ERROR([requires pthread])])
 
 PKG_CHECK_MODULES([ZSTD], [libzstd >= 1.4.9])
+PKG_CHECK_MODULES([LZ4], [liblz4 >= 1.8.3])
 PKG_CHECK_MODULES([CHECK], [check])
 
 AX_IS_RELEASE([git-directory])

--- a/libzseek.pc.in
+++ b/libzseek.pc.in
@@ -7,7 +7,7 @@ Name: libzseek
 Description: Random access decompression library
 Version: @VERSION@
 Requires:
-Requires.private: libzstd >= 1.4.9
+Requires.private: libzstd >= 1.4.9 liblz4 >= 1.8.3
 Libs: -L${libdir} -lzseek
-Libs.private: @ZSTD_LIBS@
+Libs.private: @ZSTD_LIBS@ @LZ4_LIBS@
 Cflags: -I${includedir}/

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -1,0 +1,125 @@
+#include <stdlib.h>     // malloc, realloc, free
+#include <string.h>     // memset, memmove
+
+#include "buffer.h"
+
+struct zseek_buffer {
+    void *data;
+    size_t size;
+    size_t capacity;
+};
+
+zseek_buffer_t *zseek_buffer_new(size_t capacity)
+{
+    zseek_buffer_t *buffer = malloc(sizeof(*buffer));
+    if (!buffer)
+        goto fail;
+    memset(buffer, 0, sizeof(*buffer));
+
+    if (!zseek_buffer_reserve(buffer, capacity))
+        goto fail_w_buffer;
+
+    return buffer;
+
+fail_w_buffer:
+    free(buffer);
+fail:
+    return NULL;
+}
+
+void zseek_buffer_free(zseek_buffer_t *buffer)
+{
+    if (!buffer)
+        return;
+
+    free(buffer->data);
+    free(buffer);
+}
+
+size_t zseek_buffer_size(zseek_buffer_t *buffer)
+{
+    if (!buffer)
+        return 0;
+
+    return buffer->size;
+}
+
+size_t zseek_buffer_capacity(zseek_buffer_t *buffer)
+{
+    if (!buffer)
+        return 0;
+
+    return buffer->capacity;
+}
+
+void *zseek_buffer_data(zseek_buffer_t *buffer)
+{
+    if (!buffer)
+        return NULL;
+
+    return buffer->data;
+}
+
+bool zseek_buffer_push(zseek_buffer_t *buffer, const void *data, size_t len)
+{
+    if (!buffer)
+        return false;
+
+    if (!data)
+        return len == 0;
+
+    size_t new_size = buffer->size + len;
+    if (!zseek_buffer_reserve(buffer, new_size))
+        return false;
+
+    memmove((uint8_t*)buffer->data + buffer->size, data, len);
+    buffer->size = new_size;
+
+    return true;
+}
+
+bool zseek_buffer_reserve(zseek_buffer_t *buffer, size_t capacity)
+{
+    if (!buffer)
+        return false;
+
+    if (capacity <= buffer->capacity)
+        return true;
+
+    // TODO OPT: Use different reallocation strategy? (always power of 2?)
+    size_t new_capacity = 2 * buffer->capacity;
+    if (capacity > new_capacity)
+        new_capacity = capacity;
+
+    void *new_data = realloc(buffer->data, new_capacity);
+    if (!new_data)
+        return false;
+    buffer->data = new_data;
+    buffer->capacity = new_capacity;
+
+    return true;
+}
+
+bool zseek_buffer_resize(zseek_buffer_t *buffer, size_t size)
+{
+    if (!buffer)
+        return false;
+
+    if (!zseek_buffer_reserve(buffer, size))
+        return false;
+
+    if (size > buffer->size)
+        memset((uint8_t*)buffer->data + buffer->size, 0, size - buffer->size);
+
+    buffer->size = size;
+
+    return true;
+}
+
+void zseek_buffer_reset(zseek_buffer_t *buffer)
+{
+    if (!buffer)
+        return;
+
+    buffer->size = 0;
+}

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -1,0 +1,84 @@
+#ifndef BUFFER_H
+#define BUFFER_H
+
+#include <stddef.h>     // size_t
+#include <stdint.h>     // uint*_t
+#include <stdbool.h>    // bool
+
+typedef struct zseek_buffer zseek_buffer_t;
+
+/**
+ * Creates a new buffer with a capacity of at least @p capacity bytes.
+ */
+zseek_buffer_t *zseek_buffer_new(size_t capacity);
+
+/**
+ * Frees the buffer pointed to by @p buffer.
+ */
+void zseek_buffer_free(zseek_buffer_t *buffer);
+
+/**
+ * Returns the current size of @p buffer in bytes.
+ *
+ * @attention Not safe to call concurrently (unlocked).
+ */
+size_t zseek_buffer_size(zseek_buffer_t *buffer);
+
+/**
+ * Returns the current capacity of @p buffer in bytes.
+ *
+ * @attention Not safe to call concurrently (unlocked).
+ */
+size_t zseek_buffer_capacity(zseek_buffer_t *buffer);
+
+/**
+ * Returns a pointer to the underlying data of @p buffer.
+ *
+ * @attention Not safe to call concurrently (unlocked).
+ */
+void *zseek_buffer_data(zseek_buffer_t *buffer);
+
+/**
+ * Pushes @p len bytes from @p data to the end of @p buffer.
+ * Returns @a false on error.
+ *
+ * @note Copies from @p data
+ *
+ * @attention Not safe to call concurrently (unlocked).
+ */
+bool zseek_buffer_push(zseek_buffer_t *buffer, const void *data, size_t len);
+
+/**
+ * Ensure the capacity of @p buffer is >= @p capacity.
+ * Returns @a false on error.
+ *
+ * @note Capacity is not changed if @p capacity is less than current capacity
+ *
+ * @attention Not safe to call concurrently (unlocked).
+ */
+bool zseek_buffer_reserve(zseek_buffer_t *buffer, size_t capacity);
+
+/**
+ * Resizes @p buffer to @p size bytes.
+ * If @p size is greater than current size, the additional space is
+ * zero-initialized. If @p size is less than current size, the first @p size
+ * bytes are kept.
+ *
+ * Returns @a false on error.
+ *
+ * @note Capacity is not changed if @p size if less than current size
+ *
+ * @attention Not safe to call concurrently (unlocked).
+ */
+bool zseek_buffer_resize(zseek_buffer_t *buffer, size_t size);
+
+/**
+ * Resets @p buffer to zero-size.
+ *
+ * @note Capacity is not changed
+ *
+ * @attention Not safe to call concurrently (unlocked).
+ */
+void zseek_buffer_reset(zseek_buffer_t *buffer);
+
+#endif  // BUFFER_H

--- a/src/zseek.h
+++ b/src/zseek.h
@@ -131,12 +131,21 @@ typedef struct {
 } zseek_zstd_param_t;
 
 /**
+ * Compression controls for lz4
+ */
+typedef struct {
+    /** Compression level (default = 0). Values < 0 trigger "acceleration" */
+    int compression_level;
+} zseek_lz4_param_t;
+
+/**
  * Collection of algorithm specific control options
  */
 typedef struct {
     zseek_compression_type_t type;
     union {
         zseek_zstd_param_t zstd_params;
+        zseek_lz4_param_t lz4_params;
     } params;
 } zseek_compression_param_t;
 

--- a/src/zseek.h
+++ b/src/zseek.h
@@ -1,7 +1,7 @@
 /**
  * @defgroup libzseek Efficient compressed file abstraction
  *
- * Efficient sequential write and random access read API using ZSTD.
+ * Efficient sequential write and random access read API.
  *
  * The file must be written out sequentially in one go,
  * but can be opened for random reads using offsets and sizes
@@ -110,7 +110,8 @@ typedef struct {
  * Supported compression algorithms
  */
 typedef enum {
-    ZSEEK_ZSTD = 0
+    ZSEEK_ZSTD = 0,
+    ZSEEK_LZ4,
 } zseek_compression_type_t;
 
 /**

--- a/src/zseek.h
+++ b/src/zseek.h
@@ -162,6 +162,8 @@ typedef struct {
     size_t frames;
     /** Estimate for compressed data size in bytes. Always <= actual size. */
     size_t compressed_size;
+    /** Estimate for buffered data size in bytes. Always <= actual size. */
+    size_t buffer_size;
 } zseek_writer_stats_t;
 
 /**
@@ -178,6 +180,8 @@ typedef struct {
     size_t cache_memory;
     /** Number of frames currently cached */
     size_t cached_frames;
+    /** Estimate for buffered data size in bytes. Always <= actual size. */
+    size_t buffer_size;
 } zseek_reader_stats_t;
 
 /**

--- a/test/test_buffer.c
+++ b/test/test_buffer.c
@@ -1,0 +1,216 @@
+#include <stdlib.h>
+
+#include <check.h>
+
+#include "../src/buffer.h"
+
+// TODO OPT: Mock malloc() / free()
+
+START_TEST(test_buffer_new)
+{
+    size_t capacity = 5;
+    zseek_buffer_t *buffer = zseek_buffer_new(capacity);
+    ck_assert(buffer != NULL);
+    ck_assert(zseek_buffer_capacity(buffer) >= capacity);
+    ck_assert(zseek_buffer_size(buffer) == 0);
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_push_null)
+{
+    ck_assert(!zseek_buffer_push(NULL, NULL, 0));
+}
+END_TEST
+
+START_TEST(test_buffer_push)
+{
+    zseek_buffer_t *buffer = zseek_buffer_new(0);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+
+    uint8_t data[] = {0, 1, 2, 3, 4};
+    ck_assert(zseek_buffer_push(buffer, data, sizeof(data)));
+    ck_assert(zseek_buffer_size(buffer) == sizeof(data) / sizeof(data[0]));
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_free_null)
+{
+    zseek_buffer_free(NULL);
+}
+END_TEST
+
+START_TEST(test_buffer_free)
+{
+    zseek_buffer_t *buffer = zseek_buffer_new(0);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+    uint8_t data[] = {0, 1, 2, 3, 4};
+    ck_assert_msg(zseek_buffer_push(buffer, data, sizeof(data)),
+        "failed to push data");
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_size_null)
+{
+    ck_assert(zseek_buffer_size(NULL) == 0);
+}
+END_TEST
+
+START_TEST(test_buffer_size)
+{
+    zseek_buffer_t *buffer = zseek_buffer_new(0);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+    uint8_t data[] = {0, 1, 2, 3, 4};
+    ck_assert_msg(zseek_buffer_push(buffer, data, sizeof(data)),
+        "failed to push data");
+
+    ck_assert(zseek_buffer_size(buffer) == sizeof(data));
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_capacity_null)
+{
+    ck_assert(zseek_buffer_capacity(NULL) == 0);
+}
+END_TEST
+
+START_TEST(test_buffer_capacity)
+{
+    size_t capacity = 4;
+    zseek_buffer_t *buffer = zseek_buffer_new(capacity);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+
+    ck_assert(zseek_buffer_capacity(buffer) >= capacity);
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_data_null)
+{
+    ck_assert(zseek_buffer_data(NULL) == NULL);
+}
+END_TEST
+
+START_TEST(test_buffer_data)
+{
+    zseek_buffer_t *buffer = zseek_buffer_new(0);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+    uint8_t data[] = {0, 1, 2, 3, 4};
+    ck_assert_msg(zseek_buffer_push(buffer, data, sizeof(data)),
+        "failed to push data");
+
+    ck_assert(zseek_buffer_data(buffer) != NULL);
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_reserve_null)
+{
+    ck_assert(!zseek_buffer_reserve(NULL, 0));
+}
+END_TEST
+
+START_TEST(test_buffer_reserve)
+{
+    zseek_buffer_t *buffer = zseek_buffer_new(0);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+
+    size_t capacity = 6;
+    ck_assert(zseek_buffer_reserve(buffer, capacity));
+    ck_assert(zseek_buffer_capacity(buffer) >= capacity);
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_resize_null)
+{
+    ck_assert(!zseek_buffer_resize(NULL, 0));
+}
+END_TEST
+
+START_TEST(test_buffer_resize)
+{
+    zseek_buffer_t *buffer = zseek_buffer_new(0);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+    uint8_t data[] = {0, 1, 2, 3, 4};
+    ck_assert_msg(zseek_buffer_push(buffer, data, sizeof(data)),
+        "failed to push data");
+
+    size_t size = 10;
+    ck_assert(zseek_buffer_resize(buffer, size));
+    ck_assert(zseek_buffer_size(buffer) == size);
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+START_TEST(test_buffer_reset_null)
+{
+    zseek_buffer_reset(NULL);
+}
+END_TEST
+
+START_TEST(test_buffer_reset)
+{
+    zseek_buffer_t *buffer = zseek_buffer_new(0);
+    ck_assert_msg(buffer != NULL, "failed to create buffer");
+    uint8_t data[] = {0, 1, 2, 3, 4};
+    ck_assert_msg(zseek_buffer_push(buffer, data, sizeof(data)),
+        "failed to push data");
+
+    zseek_buffer_reset(buffer);
+    ck_assert(zseek_buffer_size(buffer) == 0);
+
+    zseek_buffer_free(buffer);
+}
+END_TEST
+
+Suite *buffer_suite(void)
+{
+    Suite *s = suite_create("buffer");
+    TCase *tc_core = tcase_create("Core");
+
+    tcase_add_test(tc_core, test_buffer_new);
+    tcase_add_test(tc_core, test_buffer_push_null);
+    tcase_add_test(tc_core, test_buffer_push);
+    tcase_add_test(tc_core, test_buffer_free_null);
+    tcase_add_test(tc_core, test_buffer_free);
+    tcase_add_test(tc_core, test_buffer_size_null);
+    tcase_add_test(tc_core, test_buffer_size);
+    tcase_add_test(tc_core, test_buffer_capacity_null);
+    tcase_add_test(tc_core, test_buffer_capacity);
+    tcase_add_test(tc_core, test_buffer_data_null);
+    tcase_add_test(tc_core, test_buffer_data);
+    tcase_add_test(tc_core, test_buffer_reserve_null);
+    tcase_add_test(tc_core, test_buffer_reserve);
+    tcase_add_test(tc_core, test_buffer_resize_null);
+    tcase_add_test(tc_core, test_buffer_resize);
+    tcase_add_test(tc_core, test_buffer_reset_null);
+    tcase_add_test(tc_core, test_buffer_reset);
+
+    suite_add_tcase(s, tc_core);
+
+    return s;
+}
+
+int main(void)
+{
+    Suite *s = buffer_suite();
+    SRunner *sr = srunner_create(s);
+
+    srunner_run_all(sr, CK_NORMAL);
+    int number_failed = srunner_ntests_failed(sr);
+    srunner_free(sr);
+
+    return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
This adds support for (de)compression using lz4:

- Uses the "standard" framing format, thus compatible with lz4 command line tools.
- No breaking changes to the API.
- Example and benchmark updated.

All feedback more than welcome!