### PR TITLE
Optimize lz4 compression and decompression

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([libzseek], [2.1.0], [Fotis Xenakis <foxen@windowslive.com>])
 #   3. If interfaces have been added, increment age.
 #   4. If interfaces have been removed/changed, set age to 0.
 AC_SUBST(LIBZSEEK_CURRENT, 2)
-AC_SUBST(LIBZSEEK_REVISION, 1)
+AC_SUBST(LIBZSEEK_REVISION, 2)
 AC_SUBST(LIBZSEEK_AGE, 0)
 
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -108,8 +108,7 @@ bool zseek_buffer_resize(zseek_buffer_t *buffer, size_t size)
     if (!zseek_buffer_reserve(buffer, size))
         return false;
 
-    if (size > buffer->size)
-        memset((uint8_t*)buffer->data + buffer->size, 0, size - buffer->size);
+    // TODO OPT: zero-init new memory, if new size > old size, in debug builds?
 
     buffer->size = size;
 

--- a/src/buffer.h
+++ b/src/buffer.h
@@ -61,7 +61,7 @@ bool zseek_buffer_reserve(zseek_buffer_t *buffer, size_t capacity);
 /**
  * Resizes @p buffer to @p size bytes.
  * If @p size is greater than current size, the additional space is
- * zero-initialized. If @p size is less than current size, the first @p size
+ * uninitialized. If @p size is less than current size, the first @p size
  * bytes are kept.
  *
  * Returns @a false on error.

--- a/src/compress.c
+++ b/src/compress.c
@@ -558,9 +558,69 @@ static bool zseek_write_zstd(zseek_writer_t *writer, const void *buf,
     return true;
 }
 
+/**
+ * Compress and write out a whole frame
+ */
+static bool compress_frame_lz4(zseek_writer_t *writer, const void *buf,
+    size_t len, char errbuf[ZSEEK_ERRBUF_SIZE])
+{
+    // Resize output buffer
+    writer->preferences.frameInfo.contentSize = writer->frame_uc;
+    size_t max_cdata_len = LZ4F_compressFrameBound(len, &writer->preferences);
+    if (!zseek_buffer_resize(writer->cbuf, max_cdata_len)) {
+        set_error(errbuf, "failed to resize output buffer");
+        return false;
+    }
+    void *cbuf_data = zseek_buffer_data(writer->cbuf);
+    assert(cbuf_data);
+    // Compress frame
+    size_t cdata_len = LZ4F_compressFrame(cbuf_data, max_cdata_len, buf, len,
+        &writer->preferences);
+    if (LZ4F_isError(cdata_len)) {
+        set_error(errbuf, "%s: %s", "compress frame",
+            LZ4F_getErrorName(cdata_len));
+        return false;
+    }
+    // Correct buffer size (shrinks it, should not fail)
+    assert(zseek_buffer_resize(writer->cbuf, cdata_len));
+    writer->frame_uc += len;
+    writer->frame_cm += cdata_len;
+
+    // Write output
+    if (!writer->user_file.write(cbuf_data, cdata_len,
+        writer->user_file.user_data)) {
+
+        // TODO OPT: Use errno if user_file.pread sets it
+        set_error(errbuf, "write to file failed");
+        return false;
+    }
+
+    // Log frame
+    size_t r = ZSTD_seekable_logFrame(writer->fl, writer->frame_cm,
+        writer->frame_uc, 0);
+    if (ZSTD_isError(r)) {
+        set_error(errbuf, "log frame: %s\n", ZSTD_getErrorName(r));
+        return false;
+    }
+
+    // Reset buffers and counters
+    writer->total_cm += writer->frame_cm;
+    writer->frame_uc = 0;
+    writer->frame_cm = 0;
+    zseek_buffer_reset(writer->cbuf);
+
+    return true;
+}
+
 static bool zseek_write_lz4(zseek_writer_t *writer, const void *buf, size_t len,
     char errbuf[ZSEEK_ERRBUF_SIZE])
 {
+    if (writer->frame_cm == 0 && len >= writer->min_frame_size) {
+        // Compress frame directly from buf, to avoid copying
+        // TODO OPT: Reuse end_frame_lz4 for this
+        return compress_frame_lz4(writer, buf, len, errbuf);
+    }
+
     // Buffer uncompressed data
     if (!zseek_buffer_push(writer->ubuf, buf, len)) {
         set_error(errbuf, "failed to buffer uncompressed data");

--- a/src/compress.c
+++ b/src/compress.c
@@ -185,8 +185,8 @@ static zseek_writer_t *zseek_writer_open_full_lz4(zseek_write_file_t user_file,
     writer->preferences.compressionLevel = compression_level;
     // Avoid unnecessary copies since we compress all at once anyway
     writer->preferences.autoFlush = 1;
-    // Allow block sizes of maximum supported size
-    writer->preferences.frameInfo.blockSizeID = LZ4F_max4MB;
+    // Use smaller block sizes to reduce buffering
+    writer->preferences.frameInfo.blockSizeID = LZ4F_max64KB;
 
     LZ4F_cctx *cctx;
     LZ4F_errorCode_t r = LZ4F_createCompressionContext(&cctx, LZ4F_VERSION);


### PR DESCRIPTION
This tries to optimize the LZ4 compression and decompression paths, _without changing the API_. Changes are mostly around buffering and trying to eliminate data copies where possible.

Compression was measured to gain ~10% in performance when compressing large amounts of data.

Decompression only benefits when scanning a file sequentially, in which case disabling the cache (passing `cache_size = 0` to `zseek_reader_open()`) leads to a <=10% performance gain.

**NOTE**: the zstd side is unaffected. Most of these optimizations would apply to it too and are subject to future benchmarking and possible backporting.