### PR TITLE
Add per-call user data

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,8 +6,8 @@ AC_INIT([libzseek], [2.1.0], [Fotis Xenakis <foxen@windowslive.com>])
 #   2. If interfaces have been added/removed/changed, increment current and set revision to 0.
 #   3. If interfaces have been added, increment age.
 #   4. If interfaces have been removed/changed, set age to 0.
-AC_SUBST(LIBZSEEK_CURRENT, 2)
-AC_SUBST(LIBZSEEK_REVISION, 2)
+AC_SUBST(LIBZSEEK_CURRENT, 3)
+AC_SUBST(LIBZSEEK_REVISION, 0)
 AC_SUBST(LIBZSEEK_AGE, 0)
 
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/seek_table.h
+++ b/src/seek_table.h
@@ -18,7 +18,7 @@ size_t ZSTD_seekable_writeSeekTable(ZSTD_frameLog* fl, ZSTD_outBuffer* output);
  * Parse and return the seek table found in the last frame contained in @p fin,
  * or NULL on error.
  */
-ZSTD_seekTable *read_seek_table(zseek_read_file_t user_file);
+ZSTD_seekTable *read_seek_table(zseek_read_file_t user_file, void *call_data);
 /**
  * Free the seek table pointed to by @p st.
  */

--- a/test/example.c
+++ b/test/example.c
@@ -33,7 +33,7 @@ static bool decompress(const char *ufilename, const char *cfilename)
     }
 
     char errbuf[ZSEEK_ERRBUF_SIZE];
-    zseek_reader_t *reader = zseek_reader_open(cfile, 1, errbuf);
+    zseek_reader_t *reader = zseek_reader_open(cfile, 1, NULL, errbuf);
     if (!reader) {
         fprintf(stderr, "decompress: zseek_reader_open: %s\n", errbuf);
         goto fail_w_cfile;
@@ -63,7 +63,8 @@ static bool decompress(const char *ufilename, const char *cfilename)
         size_t to_read = uread;
         while (to_read > 0) {
             ssize_t dread = zseek_pread(reader,
-                (uint8_t*)dbuf + (offset % buf_len), to_read, offset, errbuf);
+                (uint8_t*)dbuf + (offset % buf_len), to_read, offset, NULL,
+                    errbuf);
             if (dread == -1) {
                 fprintf(stderr, "decompress: zseek_pread: %s\n", errbuf);
                 goto fail_w_dbuf;
@@ -89,7 +90,7 @@ static bool decompress(const char *ufilename, const char *cfilename)
     free(dbuf);
     free(ubuf);
 
-    if (!zseek_reader_close(reader, errbuf)) {
+    if (!zseek_reader_close(reader, NULL, errbuf)) {
         fprintf(stderr, "decompress: zseek_reader_close: %s\n", errbuf);
         goto fail_w_cfile;
     }
@@ -111,7 +112,7 @@ fail_w_dbuf:
 fail_w_ubuf:
     free(ubuf);
 fail_w_reader:
-    zseek_reader_close(reader, errbuf);
+    zseek_reader_close(reader, NULL, errbuf);
 fail_w_cfile:
     fclose(cfile);
 fail_w_ufile:
@@ -157,7 +158,7 @@ static bool compress(const char *ufilename, const char *cfilename,
         goto fail_w_cfile;
     }
     zseek_writer_t *writer = zseek_writer_open(cfile, &param, MIN_FRAME_SIZE,
-        errbuf);
+        NULL, errbuf);
     if (!writer) {
         fprintf(stderr, "compress: zseek_writer_open: %s\n", errbuf);
         goto fail_w_cfile;
@@ -178,7 +179,7 @@ static bool compress(const char *ufilename, const char *cfilename,
             goto fail_w_buf;
         }
 
-        if (!zseek_write(writer, buf, uread, errbuf)) {
+        if (!zseek_write(writer, buf, uread, NULL, errbuf)) {
             fprintf(stderr, "compress: zseek_write: %s\n", errbuf);
             goto fail_w_buf;
         }
@@ -187,7 +188,7 @@ static bool compress(const char *ufilename, const char *cfilename,
 
     free(buf);
 
-    if (!zseek_writer_close(writer, errbuf)) {
+    if (!zseek_writer_close(writer, NULL, errbuf)) {
         fprintf(stderr, "compress: zseek_writer_close: %s\n", errbuf);
         goto fail_w_cfile;
     }
@@ -207,7 +208,7 @@ static bool compress(const char *ufilename, const char *cfilename,
 fail_w_buf:
     free(buf);
 fail_w_writer:
-    zseek_writer_close(writer, errbuf);
+    zseek_writer_close(writer, NULL, errbuf);
 fail_w_cfile:
     fclose(cfile);
 fail_w_ufile:


### PR DESCRIPTION
This allows the user to correlate and / or pass data between the zseek calls and the I/O callbacks.

**NOTE** This is a breaking change, the version and tests have been updated accordingly.