### PR TITLE
Optimize zstd compression and decompression

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([libzseek], [2.1.0], [Fotis Xenakis <foxen@windowslive.com>])
 #   3. If interfaces have been added, increment age.
 #   4. If interfaces have been removed/changed, set age to 0.
 AC_SUBST(LIBZSEEK_CURRENT, 3)
-AC_SUBST(LIBZSEEK_REVISION, 0)
+AC_SUBST(LIBZSEEK_REVISION, 1)
 AC_SUBST(LIBZSEEK_AGE, 0)
 
 AC_CONFIG_AUX_DIR([build-aux])

--- a/src/compress.c
+++ b/src/compress.c
@@ -147,7 +147,8 @@ static zseek_writer_t *zseek_writer_open_full_zstd(zseek_write_file_t user_file,
     }
     writer->fl = fl;
 
-    zseek_buffer_t *cbuf = zseek_buffer_new(0);
+    size_t cbuf_len = ZSTD_compressBound(min_frame_size);
+    zseek_buffer_t *cbuf = zseek_buffer_new(cbuf_len);
     if (!cbuf) {
         set_error(errbuf, "buffer creation failed");
         goto fail_w_fl;
@@ -333,7 +334,9 @@ static bool zseek_writer_close_zstd(zseek_writer_t *writer,
         }
     }
 
-    size_t cbuf_len = 4096;
+    size_t cbuf_len = zseek_buffer_capacity(writer->cbuf);
+    if (cbuf_len < 4096)
+        cbuf_len = 4096;
     if (!zseek_buffer_resize(writer->cbuf, cbuf_len) && !is_error) {
         set_error(errbuf, "resize output buffer failed");
         is_error = true;

--- a/src/decompress.c
+++ b/src/decompress.c
@@ -29,11 +29,11 @@ struct zseek_reader {
     zseek_compression_type_t type;
     union {
         // TODO: If there's contention, use one dctx per read()
-        ZSTD_DCtx *dctx_zstd;
         struct {
-            LZ4F_dctx *dctx_lz4;
-            zseek_buffer_t *dbuf;   // discard buffer
+            ZSTD_DCtx *dctx_zstd;
+            ZSTD_DStream *dstream_zstd;
         };
+        LZ4F_dctx *dctx_lz4;
     };
     pthread_rwlock_t lock;
 
@@ -41,6 +41,7 @@ struct zseek_reader {
     zseek_cache_t *cache;
     size_t pos;
     zseek_buffer_t *cbuf;
+    zseek_buffer_t *dbuf;   // discard buffer
 };
 
 static ssize_t default_pread(void *data, size_t size, size_t offset,
@@ -114,10 +115,17 @@ static zseek_reader_t *zseek_reader_open_full_zstd(zseek_read_file_t user_file,
     }
     reader->dctx_zstd = dctx;
 
+    ZSTD_DStream *dstream = ZSTD_createDStream();
+    if (!dstream) {
+        set_error(errbuf, "dstream creation failed");
+        goto fail_w_dctx;
+    }
+    reader->dstream_zstd = dstream;
+
     int pr = pthread_rwlock_init(&reader->lock, NULL);
     if (pr) {
         set_error_with_errno(errbuf, "initialize lock", pr);
-        goto fail_w_dctx;
+        goto fail_w_dstream;
     }
 
     reader->user_file = user_file;
@@ -129,10 +137,13 @@ static zseek_reader_t *zseek_reader_open_full_zstd(zseek_read_file_t user_file,
     }
     reader->st = st;
 
-    zseek_cache_t *cache = zseek_cache_new(cache_size);
-    if (!cache) {
-        set_error(errbuf, "cache creation failed");
-        goto fail_w_st;
+    zseek_cache_t *cache = NULL;
+    if (cache_size > 0) {
+        cache = zseek_cache_new(cache_size);
+        if (!cache) {
+            set_error(errbuf, "cache creation failed");
+            goto fail_w_st;
+        }
     }
     reader->cache = cache;
 
@@ -143,14 +154,25 @@ static zseek_reader_t *zseek_reader_open_full_zstd(zseek_read_file_t user_file,
     }
     reader->cbuf = cbuf;
 
+    zseek_buffer_t *dbuf = zseek_buffer_new(0);
+    if (!dbuf) {
+        set_error(errbuf, "discard buffer creation failed");
+        goto fail_w_cbuf;
+    }
+    reader->dbuf = dbuf;
+
     return reader;
 
+fail_w_cbuf:
+    zseek_buffer_free(cbuf);
 fail_w_cache:
     zseek_cache_free(cache);
 fail_w_st:
     seek_table_free(st);
 fail_w_lock:
     pthread_rwlock_destroy(&reader->lock);
+fail_w_dstream:
+    ZSTD_freeDStream(dstream);
 fail_w_dctx:
     ZSTD_freeDCtx(dctx);
 fail_w_reader:
@@ -275,6 +297,8 @@ zseek_reader_t *zseek_reader_open(FILE *cfile, size_t cache_size,
 static bool zseek_reader_close_zstd(zseek_reader_t *reader, void *call_data,
     char errbuf[ZSEEK_ERRBUF_SIZE])
 {
+    (void)call_data;
+
     bool is_error = false;
 
     int pr = pthread_rwlock_destroy(&reader->lock);
@@ -283,12 +307,19 @@ static bool zseek_reader_close_zstd(zseek_reader_t *reader, void *call_data,
         is_error = true;
     }
 
-    size_t r = ZSTD_freeDCtx(reader->dctx_zstd);
+    size_t r = ZSTD_freeDStream(reader->dstream_zstd);
+    if (ZSTD_isError(r) && !is_error) {
+        set_error(errbuf, "%s: %s", "free dstream", ZSTD_getErrorName(r));
+        is_error = true;
+    }
+
+    r = ZSTD_freeDCtx(reader->dctx_zstd);
     if (ZSTD_isError(r) && !is_error) {
         set_error(errbuf, "%s: %s", "free context", ZSTD_getErrorName(r));
         is_error = true;
     }
 
+    zseek_buffer_free(reader->dbuf);
     zseek_buffer_free(reader->cbuf);
     zseek_cache_free(reader->cache);
     seek_table_free(reader->st);
@@ -343,10 +374,108 @@ bool zseek_reader_close(zseek_reader_t *reader, void *call_data,
     }
 }
 
+static ssize_t zseek_pread_zstd_no_cache(zseek_reader_t *reader, void *buf,
+    size_t count, size_t offset, void *call_data,
+    char errbuf[ZSEEK_ERRBUF_SIZE])
+{
+    // TODO OPT: Use the cache, only for reading?
+
+    ssize_t frame_idx = offset_to_frame_idx(reader->st, offset);
+    if (frame_idx == -1)
+        return 0;
+
+    int pr = pthread_rwlock_wrlock(&reader->lock);
+    if (pr) {
+        set_error_with_errno(errbuf, "lock for writing", pr);
+        goto fail;
+    }
+
+    // Resize compressed buffer
+    size_t frame_csize = frame_size_c(reader->st, frame_idx);
+    if (!zseek_buffer_resize(reader->cbuf, frame_csize)) {
+        set_error(errbuf, "resize compressed buffer");
+        goto fail_w_lock;
+    }
+    void *cbuf_data = zseek_buffer_data(reader->cbuf);
+    assert(cbuf_data);
+    // Read compressed frame
+    off_t frame_offset = frame_offset_c(reader->st, frame_idx);
+    ssize_t _read = reader->user_file.pread(cbuf_data, frame_csize,
+        (size_t)frame_offset, reader->user_file.user_data, call_data);
+    if (_read != (ssize_t)frame_csize) {
+        if (_read >= 0)
+            set_error(errbuf, "unexpected EOF");
+        else
+            // TODO OPT: Use errno if user_file.pread sets it
+            set_error(errbuf, "read file failed");
+        goto fail_w_lock;
+    }
+
+    size_t r = ZSTD_initDStream(reader->dstream_zstd);
+    if (ZSTD_isError(r)) {
+        set_error(errbuf, "%s: %s", "initialize dstream", ZSTD_getErrorName(r));
+        goto fail_w_lock;
+    }
+    // Discard any excess leading data
+    ZSTD_inBuffer inb = { .src = cbuf_data, .size = frame_csize };
+    size_t offset_in_frame = offset - frame_offset_d(reader->st, frame_idx);
+    if (offset_in_frame > 0) {
+        // Resize discard buffer
+        if (!zseek_buffer_resize(reader->dbuf, offset_in_frame)) {
+            set_error(errbuf, "resize discard buffer");
+            goto fail_w_lock;
+        }
+        void *dbuf_data = zseek_buffer_data(reader->dbuf);
+        assert(dbuf_data);
+        // Decompress discard data
+        size_t to_decompress = offset_in_frame;
+        ZSTD_outBuffer outb = { .dst = dbuf_data, .size = to_decompress };
+        while (outb.pos < outb.size) {
+            r = ZSTD_decompressStream(reader->dstream_zstd, &outb, &inb);
+            if (ZSTD_isError(r)) {
+                set_error(errbuf, "%s: %s", "decompress discard data",
+                    ZSTD_getErrorName(r));
+                goto fail_w_lock;
+            }
+        }
+    }
+
+    // Decompress user data
+    size_t frame_dsize = frame_size_d(reader->st, frame_idx);
+    size_t to_decompress = MIN(count, frame_dsize - offset_in_frame);
+    ZSTD_outBuffer outb = { .dst = buf, .size = to_decompress };
+    while (outb.pos < outb.size) {
+        r = ZSTD_decompressStream(reader->dstream_zstd, &outb, &inb);
+        if (ZSTD_isError(r)) {
+            set_error(errbuf, "%s: %s", "decompress user data",
+                ZSTD_getErrorName(r));
+            goto fail_w_lock;
+        }
+    }
+
+    pr = pthread_rwlock_unlock(&reader->lock);
+    if (pr) {
+        set_error_with_errno(errbuf, "unlock", pr);
+        goto fail;
+    }
+
+    return to_decompress;
+
+fail_w_lock:
+    pthread_rwlock_unlock(&reader->lock);
+fail:
+    return -1;
+}
+
 static ssize_t zseek_pread_zstd(zseek_reader_t *reader, void *buf, size_t count,
     size_t offset, void *call_data, char errbuf[ZSEEK_ERRBUF_SIZE])
 {
-    // TODO: Try to return as much as possible (multiple frames).
+    // TODO OPT: Try to return as much as possible (multiple frames), to avoid
+    // the repeated fs read and zseek_read overhead?
+
+    if (!reader->cache)
+        return zseek_pread_zstd_no_cache(reader, buf, count, offset, call_data,
+            errbuf);
 
     ssize_t frame_idx = offset_to_frame_idx(reader->st, offset);
     if (frame_idx == -1)
@@ -737,8 +866,11 @@ bool zseek_reader_stats(zseek_reader_t *reader, zseek_reader_stats_t *stats,
     // NOTE: This is an _estimate_ because the underlying compression lib may
     // buffer too in its context object.
     size_t buffer_size = zseek_buffer_capacity(reader->cbuf);
-    if (reader->type == ZSEEK_LZ4)
-        buffer_size += zseek_buffer_capacity(reader->dbuf);
+    buffer_size += zseek_buffer_capacity(reader->dbuf);
+    if (reader->type == ZSEEK_ZSTD) {
+        buffer_size += ZSTD_sizeof_DCtx(reader->dctx_zstd);
+        buffer_size += ZSTD_sizeof_DStream(reader->dstream_zstd);
+    }
 
     pr = pthread_rwlock_unlock(&reader->lock);
     if (pr) {


### PR DESCRIPTION
This tries to optimize the zstd compression and decompression paths, _without changing the API_. Changes are mostly around buffering and trying to eliminate data copies where possible, similar to https://github.com/foxeng/libzseek/pull/27.

Compression was measured to gain ~8% in performance when compressing large amounts of data (single-threaded).

**NOTE**: Keeping the multi-threaded compression path, using the zstd streaming mode, although it adds up in code size and complexity slightly. Any strong arguments in favor / against it are welcome :) 