### PR TITLE
build: Meson build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([libzseek], [3.2.0], [Fotis Xenakis <foxen@windowslive.com>])
+AC_INIT([libzseek], [3.0.2], [Fotis Xenakis <foxen@windowslive.com>])
 
 # Before building a new release, the library version info should be modified.
 # Apply these instructions sequentially:

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('libzseek', 'c',
     default_options: ['c_std=c11', 'warning_level=3', 'werror=true'],
     license: 'BSD-3-Clause',
-    version: '3.2.0')
+    version: '3.0.2')
 add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
 
@@ -23,7 +23,7 @@ libzseek = library('zseek',
     dependencies: [threads_dep, zstd_dep, lz4_dep],
     gnu_symbol_visibility: 'hidden',
     install: true,
-    soversion: '3.2.0')
+    version: '3.0.2')
 libzseek_dep = declare_dependency(
     include_directories: 'src',
     link_with: libzseek)

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('libzseek', 'c',
     default_options: ['c_std=c11', 'warning_level=3', 'werror=true'],
     license: 'BSD-3-Clause',
+    meson_version: '>=0.50.0',
     version: '3.0.2')
 add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
@@ -70,10 +71,9 @@ doxyfile = configure_file(input: 'Doxyfile.in',
         'NAME': meson.project_name(),
         'DESCRIPTION': project_desc,
         'VERSION': meson.project_version(),
-        'TOP_SRCDIR': meson.project_source_root(),
-        'TOP_BUILDDIR': meson.project_build_root(),
-    },
-    install: false)
+        'TOP_SRCDIR': meson.current_source_dir(),
+        'TOP_BUILDDIR': meson.current_build_dir(),
+    })
 doxygen = find_program('doxygen', disabler: true, required: false)
 doc_target = custom_target('doc',
     input: doxyfile,


### PR DESCRIPTION
This corrects and aligns the artifact versions between the meson and autotools build systems (keeping to the current autotools version). It also lowers the meson version requirement to `0.50.0` and makes this explicit too.

Thanks to @eli-schwartz for the original comments and suggestions on https://github.com/foxeng/libzseek/pull/30! Any further comment welcome as always :)